### PR TITLE
fix: import defaults from json for webpack 5 compat

### DIFF
--- a/src/constants.test.ts
+++ b/src/constants.test.ts
@@ -1,11 +1,11 @@
 import { POOL_INIT_CODE_HASH } from './constants'
 
-import { bytecode } from '@uniswap/v3-core/artifacts/contracts/UniswapV3Pool.sol/UniswapV3Pool.json'
+import IUniswapV3Pool from '@uniswap/v3-core/artifacts/contracts/UniswapV3Pool.sol/UniswapV3Pool.json'
 import { keccak256 } from '@ethersproject/solidity'
 
 // this _could_ go in constants, except that it would cost every consumer of the sdk the CPU to compute the hash
 // and load the JSON.
-const COMPUTED_INIT_CODE_HASH = keccak256(['bytes'], [bytecode])
+const COMPUTED_INIT_CODE_HASH = keccak256(['bytes'], [IUniswapV3Pool.bytecode])
 
 describe('constants', () => {
   describe('INIT_CODE_HASH', () => {

--- a/src/multicall.ts
+++ b/src/multicall.ts
@@ -1,8 +1,8 @@
 import { Interface } from '@ethersproject/abi'
-import { abi } from '@uniswap/v3-periphery/artifacts/contracts/interfaces/IMulticall.sol/IMulticall.json'
+import IMulticall from '@uniswap/v3-periphery/artifacts/contracts/interfaces/IMulticall.sol/IMulticall.json'
 
 export abstract class Multicall {
-  public static INTERFACE: Interface = new Interface(abi)
+  public static INTERFACE: Interface = new Interface(IMulticall.abi)
 
   /**
    * Cannot be constructed.

--- a/src/nonfungiblePositionManager.ts
+++ b/src/nonfungiblePositionManager.ts
@@ -13,7 +13,7 @@ import { Position } from './entities/position'
 import { ONE, ZERO } from './internalConstants'
 import { MethodParameters, toHex } from './utils/calldata'
 import { Interface } from '@ethersproject/abi'
-import { abi } from '@uniswap/v3-periphery/artifacts/contracts/NonfungiblePositionManager.sol/NonfungiblePositionManager.json'
+import INonfungiblePositionManager from '@uniswap/v3-periphery/artifacts/contracts/NonfungiblePositionManager.sol/NonfungiblePositionManager.json'
 import { PermitOptions, SelfPermit } from './selfPermit'
 import { ADDRESS_ZERO } from './constants'
 import { Pool } from './entities'
@@ -173,7 +173,7 @@ export interface RemoveLiquidityOptions {
 }
 
 export abstract class NonfungiblePositionManager {
-  public static INTERFACE: Interface = new Interface(abi)
+  public static INTERFACE: Interface = new Interface(INonfungiblePositionManager.abi)
 
   /**
    * Cannot be constructed.

--- a/src/payments.ts
+++ b/src/payments.ts
@@ -1,6 +1,6 @@
 import JSBI from 'jsbi'
 import { Interface } from '@ethersproject/abi'
-import { abi } from '@uniswap/v3-periphery/artifacts/contracts/interfaces/IPeripheryPaymentsWithFee.sol/IPeripheryPaymentsWithFee.json'
+import IPeripheryPaymentsWithFee from '@uniswap/v3-periphery/artifacts/contracts/interfaces/IPeripheryPaymentsWithFee.sol/IPeripheryPaymentsWithFee.json'
 import { Percent, Token, validateAndParseAddress } from '@uniswap/sdk-core'
 import { toHex } from './utils/calldata'
 
@@ -17,7 +17,7 @@ export interface FeeOptions {
 }
 
 export abstract class Payments {
-  public static INTERFACE: Interface = new Interface(abi)
+  public static INTERFACE: Interface = new Interface(IPeripheryPaymentsWithFee.abi)
 
   /**
    * Cannot be constructed.

--- a/src/quoter.ts
+++ b/src/quoter.ts
@@ -2,7 +2,7 @@ import { Interface } from '@ethersproject/abi'
 import { BigintIsh, Currency, CurrencyAmount, TradeType } from '@uniswap/sdk-core'
 import { encodeRouteToPath } from './utils'
 import { MethodParameters, toHex } from './utils/calldata'
-import { abi } from '@uniswap/v3-periphery/artifacts/contracts/lens/Quoter.sol/Quoter.json'
+import IQuoter from '@uniswap/v3-periphery/artifacts/contracts/lens/Quoter.sol/Quoter.json'
 import { Route } from './entities'
 import invariant from 'tiny-invariant'
 
@@ -21,7 +21,7 @@ export interface QuoteOptions {
  * calldata needed to call the quoter contract.
  */
 export abstract class SwapQuoter {
-  public static INTERFACE: Interface = new Interface(abi)
+  public static INTERFACE: Interface = new Interface(IQuoter.abi)
 
   /**
    * Produces the on-chain method name of the appropriate function within QuoterV2,

--- a/src/selfPermit.ts
+++ b/src/selfPermit.ts
@@ -1,6 +1,6 @@
 import { BigintIsh, Token } from '@uniswap/sdk-core'
 import { Interface } from '@ethersproject/abi'
-import { abi } from '@uniswap/v3-periphery/artifacts/contracts/interfaces/ISelfPermit.sol/ISelfPermit.json'
+import ISelfPermit from '@uniswap/v3-periphery/artifacts/contracts/interfaces/ISelfPermit.sol/ISelfPermit.json'
 import { toHex } from './utils'
 
 export interface StandardPermitArguments {
@@ -26,7 +26,7 @@ function isAllowedPermit(permitOptions: PermitOptions): permitOptions is Allowed
 }
 
 export abstract class SelfPermit {
-  public static INTERFACE: Interface = new Interface(abi)
+  public static INTERFACE: Interface = new Interface(ISelfPermit.abi)
 
   /**
    * Cannot be constructed.

--- a/src/staker.ts
+++ b/src/staker.ts
@@ -1,7 +1,7 @@
 import { BigintIsh, Token, validateAndParseAddress } from '@uniswap/sdk-core'
 import { MethodParameters, toHex } from './utils/calldata'
 import { defaultAbiCoder, Interface } from '@ethersproject/abi'
-import { abi } from '@uniswap/v3-staker/artifacts/contracts/UniswapV3Staker.sol/UniswapV3Staker.json'
+import IUniswapV3Staker from '@uniswap/v3-staker/artifacts/contracts/UniswapV3Staker.sol/UniswapV3Staker.json'
 import { Pool } from './entities'
 import { Multicall } from './multicall'
 
@@ -67,7 +67,7 @@ export interface WithdrawOptions {
 }
 
 export abstract class Staker {
-  public static INTERFACE: Interface = new Interface(abi)
+  public static INTERFACE: Interface = new Interface(IUniswapV3Staker.abi)
 
   protected constructor() {}
   private static INCENTIVE_KEY_ABI =

--- a/src/swapRouter.ts
+++ b/src/swapRouter.ts
@@ -6,7 +6,7 @@ import { ADDRESS_ZERO } from './constants'
 import { PermitOptions, SelfPermit } from './selfPermit'
 import { encodeRouteToPath } from './utils'
 import { MethodParameters, toHex } from './utils/calldata'
-import { abi } from '@uniswap/v3-periphery/artifacts/contracts/SwapRouter.sol/SwapRouter.json'
+import ISwapRouter from '@uniswap/v3-periphery/artifacts/contracts/SwapRouter.sol/SwapRouter.json'
 import { Multicall } from './multicall'
 import { FeeOptions, Payments } from './payments'
 
@@ -49,7 +49,7 @@ export interface SwapOptions {
  * Represents the Uniswap V3 SwapRouter, and has static methods for helping execute trades.
  */
 export abstract class SwapRouter {
-  public static INTERFACE: Interface = new Interface(abi)
+  public static INTERFACE: Interface = new Interface(ISwapRouter.abi)
 
   /**
    * Cannot be constructed.


### PR DESCRIPTION
Using named exports from JSON modules is not supported by webpack 5. Continuing to do so will break downstream consumers.
See https://webpack.js.org/migrate/5/#using-named-exports-from-json-modules