### PR TITLE
Remove async await from tickDataProvider

### DIFF
--- a/src/entities/tickDataProvider.test.ts
+++ b/src/entities/tickDataProvider.test.ts
@@ -4,10 +4,10 @@ describe('TickDataProvider', () => {
   describe('NoTickDataProvider', () => {
     const provider = new NoTickDataProvider()
     it('throws on getTick', () => {
-      expect(provider.getTick(0)).rejects.toThrow('No tick data provider was given')
+      expect(() => provider.getTick(0)).toThrow('No tick data provider was given')
     })
     it('throws on nextInitializedTickWithinOneWord', () => {
-      expect(provider.nextInitializedTickWithinOneWord(0, false, 1)).rejects.toThrow('No tick data provider was given')
+      expect(() => provider.nextInitializedTickWithinOneWord(0, false, 1)).toThrow('No tick data provider was given')
     })
   })
 })

--- a/src/entities/tickDataProvider.ts
+++ b/src/entities/tickDataProvider.ts
@@ -8,7 +8,7 @@ export interface TickDataProvider {
    * Return information corresponding to a specific tick
    * @param tick the tick to load
    */
-  getTick(tick: number): Promise<{ liquidityNet: BigintIsh }>
+  getTick(tick: number): { liquidityNet: BigintIsh }
 
   /**
    * Return the next tick that is initialized within a single word
@@ -16,7 +16,7 @@ export interface TickDataProvider {
    * @param lte Whether the next tick should be lte the current tick
    * @param tickSpacing The tick spacing of the pool
    */
-  nextInitializedTickWithinOneWord(tick: number, lte: boolean, tickSpacing: number): Promise<[number, boolean]>
+  nextInitializedTickWithinOneWord(tick: number, lte: boolean, tickSpacing: number): [number, boolean]
 }
 
 /**
@@ -25,15 +25,11 @@ export interface TickDataProvider {
  */
 export class NoTickDataProvider implements TickDataProvider {
   private static ERROR_MESSAGE = 'No tick data provider was given'
-  async getTick(_tick: number): Promise<{ liquidityNet: BigintIsh }> {
+  getTick(_tick: number): { liquidityNet: BigintIsh } {
     throw new Error(NoTickDataProvider.ERROR_MESSAGE)
   }
 
-  async nextInitializedTickWithinOneWord(
-    _tick: number,
-    _lte: boolean,
-    _tickSpacing: number
-  ): Promise<[number, boolean]> {
+  nextInitializedTickWithinOneWord(_tick: number, _lte: boolean, _tickSpacing: number): [number, boolean] {
     throw new Error(NoTickDataProvider.ERROR_MESSAGE)
   }
 }

--- a/src/entities/tickListDataProvider.test.ts
+++ b/src/entities/tickListDataProvider.test.ts
@@ -9,8 +9,8 @@ describe('TickListDataProvider', () => {
     it('throws for 0 tick spacing', () => {
       expect(() => new TickListDataProvider([], 0)).toThrow('TICK_SPACING_NONZERO')
     })
-    it('throws for uneven tick list', async () => {
-      await expect(
+    it('throws for uneven tick list', () => {
+      expect(
         () =>
           new TickListDataProvider(
             [
@@ -24,7 +24,7 @@ describe('TickListDataProvider', () => {
   })
 
   describe('#getTick', () => {
-    it('throws if tick not in list', async () => {
+    it('throws if tick not in list', () => {
       const provider = new TickListDataProvider(
         [
           { index: -1, liquidityNet: -1, liquidityGross: 1 },
@@ -32,9 +32,9 @@ describe('TickListDataProvider', () => {
         ],
         1
       )
-      await expect(provider.getTick(0)).rejects.toThrow('NOT_CONTAINED')
+      expect(() => provider.getTick(0)).toThrow('NOT_CONTAINED')
     })
-    it('gets the smallest tick from the list', async () => {
+    it('gets the smallest tick from the list', () => {
       const provider = new TickListDataProvider(
         [
           { index: -1, liquidityNet: -1, liquidityGross: 1 },
@@ -42,11 +42,11 @@ describe('TickListDataProvider', () => {
         ],
         1
       )
-      const { liquidityNet, liquidityGross } = await provider.getTick(-1)
+      const { liquidityNet, liquidityGross } = provider.getTick(-1)
       expect(liquidityNet).toEqual(JSBI.BigInt(-1))
       expect(liquidityGross).toEqual(JSBI.BigInt(1))
     })
-    it('gets the largest tick from the list', async () => {
+    it('gets the largest tick from the list', () => {
       const provider = new TickListDataProvider(
         [
           { index: -1, liquidityNet: -1, liquidityGross: 1 },
@@ -54,7 +54,7 @@ describe('TickListDataProvider', () => {
         ],
         1
       )
-      const { liquidityNet, liquidityGross } = await provider.getTick(1)
+      const { liquidityNet, liquidityGross } = provider.getTick(1)
       expect(liquidityNet).toEqual(JSBI.BigInt(1))
       expect(liquidityGross).toEqual(JSBI.BigInt(1))
     })

--- a/src/entities/tickListDataProvider.ts
+++ b/src/entities/tickListDataProvider.ts
@@ -15,11 +15,11 @@ export class TickListDataProvider implements TickDataProvider {
     this.ticks = ticksMapped
   }
 
-  async getTick(tick: number): Promise<{ liquidityNet: BigintIsh; liquidityGross: BigintIsh }> {
+  getTick(tick: number): { liquidityNet: BigintIsh; liquidityGross: BigintIsh } {
     return TickList.getTick(this.ticks, tick)
   }
 
-  async nextInitializedTickWithinOneWord(tick: number, lte: boolean, tickSpacing: number): Promise<[number, boolean]> {
+  nextInitializedTickWithinOneWord(tick: number, lte: boolean, tickSpacing: number): [number, boolean] {
     return TickList.nextInitializedTickWithinOneWord(this.ticks, tick, lte, tickSpacing)
   }
 }


### PR DESCRIPTION
Hi there,

I have been going through the UniswapV3 sdk code for some time, and I was confused that the pool was sometimes requiring async methods.  Digging further, it appears that the pieces of code that are async/await are in the tickDataProvider.  In fact, the tickDataProvider is executing synchronous code, so IMO the async/await is confusing and might lead developers to think that the SDK is sometimes talking with the node provider or doing some weird math that needs to be offloaded to a special piece of hardware, similar to how encryption in a library like bCrypt works.

I am putting in this small PR to remove the async/await from just the tickDataProvider before I do more work and remove the async requirement from things like the `pool.swap` function, which will require more work to clean the tests etc.  Maybe you have an explanation for why it was created as async/await?  

One reason I can understand is that maybe in the future you are planning to add the option to connect a node provider to the sdk methods which will then actually perform network async functions.  In that case, I would argue that it is better to leave the functions as synchronous right now and make them async if and when they actually are so.  The code will need to change significantly if they are changed to be actually async.