### PR TITLE
Add an optional factory address override for pool address computation

### DIFF
--- a/src/entities/pool.ts
+++ b/src/entities/pool.ts
@@ -41,8 +41,8 @@ export class Pool {
   private _token0Price?: Price<Token, Token>
   private _token1Price?: Price<Token, Token>
 
-  public static getAddress(tokenA: Token, tokenB: Token, fee: FeeAmount, initCodeHashManualOverride?: string): string {
-    return computePoolAddress({ factoryAddress: FACTORY_ADDRESS, fee, tokenA, tokenB, initCodeHashManualOverride })
+  public static getAddress(tokenA: Token, tokenB: Token, fee: FeeAmount, initCodeHashManualOverride?: string, factoryAddressOverride?: string): string {
+    return computePoolAddress({ factoryAddress: factoryAddressOverride ?? FACTORY_ADDRESS, fee, tokenA, tokenB, initCodeHashManualOverride })
   }
 
   /**

--- a/src/entities/pool.ts
+++ b/src/entities/pool.ts
@@ -1,4 +1,4 @@
-import { BigintIsh, Price, Token, CurrencyAmount } from '@uniswap/sdk-core'
+import { BigintIsh, CurrencyAmount, Price, Token } from '@uniswap/sdk-core'
 import JSBI from 'jsbi'
 import invariant from 'tiny-invariant'
 import { FACTORY_ADDRESS, FeeAmount, TICK_SPACINGS } from '../constants'
@@ -41,8 +41,20 @@ export class Pool {
   private _token0Price?: Price<Token, Token>
   private _token1Price?: Price<Token, Token>
 
-  public static getAddress(tokenA: Token, tokenB: Token, fee: FeeAmount, initCodeHashManualOverride?: string, factoryAddressOverride?: string): string {
-    return computePoolAddress({ factoryAddress: factoryAddressOverride ?? FACTORY_ADDRESS, fee, tokenA, tokenB, initCodeHashManualOverride })
+  public static getAddress(
+    tokenA: Token,
+    tokenB: Token,
+    fee: FeeAmount,
+    initCodeHashManualOverride?: string,
+    factoryAddressOverride?: string
+  ): string {
+    return computePoolAddress({
+      factoryAddress: factoryAddressOverride ?? FACTORY_ADDRESS,
+      fee,
+      tokenA,
+      tokenB,
+      initCodeHashManualOverride
+    })
   }
 
   /**


### PR DESCRIPTION
The factory contract address was originally uniform across all chains however, this is changing starting with Uniswap deployment on Celo.