### PR TITLE
Add leastSignificantBit function

### DIFF
--- a/src/utils/leastSignificantBit.test.ts
+++ b/src/utils/leastSignificantBit.test.ts
@@ -1,0 +1,30 @@
+import { MaxUint256 } from '@uniswap/sdk-core'
+import JSBI from 'jsbi'
+import { ONE } from '../internalConstants'
+import { leastSignificantBit } from './leastSignificantBit'
+
+describe('leastSignificantBit', () => {
+    it('throws for zero', () => {
+        expect(() => leastSignificantBit(JSBI.BigInt(0))).toThrow('ZERO')
+    })
+    it('correct value for every power of 2', () => {
+        for (let i = 1; i < 256; i++) {
+            const x = JSBI.exponentiate(JSBI.BigInt(2), JSBI.BigInt(i))
+            expect(leastSignificantBit(x)).toEqual(i)
+        }
+    })
+    it('correct value for every power of 2 - 1', () => {
+        for (let i = 2; i < 256; i++) {
+            const x = JSBI.subtract(JSBI.exponentiate(JSBI.BigInt(2), JSBI.BigInt(i)), JSBI.BigInt(1))
+            expect(leastSignificantBit(x)).toEqual(0)
+        }
+    })
+
+    it('succeeds for MaxUint256', () => {
+        expect(leastSignificantBit(MaxUint256)).toEqual(0)
+    })
+
+    it('throws for MaxUint256 + 1', () => {
+        expect(() => leastSignificantBit(JSBI.add(MaxUint256, ONE))).toThrow('MAX')
+    })
+})

--- a/src/utils/leastSignificantBit.ts
+++ b/src/utils/leastSignificantBit.ts
@@ -1,0 +1,26 @@
+import { MaxUint256 } from '@uniswap/sdk-core'
+import JSBI from 'jsbi'
+import invariant from 'tiny-invariant'
+
+const ZERO = JSBI.BigInt(0)
+const TWO = JSBI.BigInt(2)
+const ONE = JSBI.BigInt(1)
+const POWERS_OF_2 = [128, 64, 32, 16, 8, 4, 2, 1].map((pow: number): [number, JSBI] => [
+    pow,
+    JSBI.subtract(JSBI.exponentiate(TWO, JSBI.BigInt(pow)), ONE)
+])
+
+export function leastSignificantBit(x: JSBI): number {
+    invariant(JSBI.greaterThan(x, ZERO), 'ZERO')
+    invariant(JSBI.lessThanOrEqual(x, MaxUint256), 'MAX')
+
+    let lsb: number = 255
+    for (const [power, min] of POWERS_OF_2) {
+        if (JSBI.greaterThan(JSBI.bitwiseAnd(min, x), ZERO)) {
+            lsb -= power
+        } else {
+            x = JSBI.signedRightShift(x, JSBI.BigInt(power))
+        }
+    }
+    return lsb
+}


### PR DESCRIPTION
leastSignificantBit is a symmetric function to mostSignificant function and would be useful to calculate nextInitializedTickWithinOneWord.
I wrote this function referred to v3-core contract(https://github.com/Uniswap/v3-core/blob/412d9b236a1e75a98568d49b1aeb21e3a1430544/contracts/libraries/BitMath.sol#L53).
FYI all test cases were passed. 
