### PR TITLE
Add `@ethersproject/address`, `tiny-invariant`, `jsbi` explicit dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,11 +25,13 @@
   },
   "dependencies": {
     "@ethersproject/abi": "^5.0.12",
+    "@ethersproject/address": "^5.0.9",
     "@ethersproject/solidity": "^5.0.9",
     "@uniswap/sdk-core": "^3.0.1",
     "@uniswap/swap-router-contracts": "^1.2.1",
     "@uniswap/v3-periphery": "^1.1.1",
     "@uniswap/v3-staker": "1.0.0",
+    "jsbi": "^3.1.4",
     "tiny-invariant": "^1.1.0",
     "tiny-warning": "^1.0.3"
   },


### PR DESCRIPTION
# Issue

- `@ethersproject/address@^5.0.9` dependency is used in the package without being defined as an explicit dependency in `package.json`
- `jsbi@^3.1.4` dependency is used in the package without being defined as an explicit dependency in `package.json`

This impacts developers using this package as dependency resolvers (such as `npm` or `yarn`) won't automatically install missing dependencies, or will install it with incorrect (and thus perhaps incompatible) versions

# Fix

- This PR adds the missing dependencies to `package.json` without impacting the current state of `yarn.lock`