### PR TITLE
fix: add await to getInputAmount in pool.test.ts

### DIFF
--- a/src/entities/pool.test.ts
+++ b/src/entities/pool.test.ts
@@ -247,7 +247,7 @@ describe('Pool', () => {
       it('correctly handles two BigIntegers', async () => {
         const inputAmount = CurrencyAmount.fromRawAmount(USDC, 100)
         const [outputAmount] = await pool.getOutputAmount(inputAmount)
-        pool.getInputAmount(outputAmount)
+        await pool.getInputAmount(outputAmount)
         expect(outputAmount.currency.equals(DAI)).toBe(true)
         // if output is correct, function has succeeded
       })


### PR DESCRIPTION
This fix adds an `await` keyword to the `getInputAmount` function call in `pool.test.ts`, ensuring asynchronous operations complete properly before proceeding, which results in more accurate and reliable test outcomes.