### PR TITLE
fix: pin `regenerator-runtime` to `^0.14.1` via `resolutions`

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,12 @@
     "@uniswap/v3-core": "1.0.0",
     "tsdx": "^0.14.1"
   },
+  "resolutions": {
+    "regenerator-runtime": "^0.14.1"
+  },
+  "resolutionsComments": {
+    "regenerator-runtime": "Fixes https://github.com/facebook/regenerator/pull/480. It can be removed when `tsdx` updates their dependencies."
+  },
   "engines": {
     "node": ">=10"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5284,10 +5284,10 @@ regenerate@^1.4.0:
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.2.tgz#b9346d8827e8f5a32f7ba29637d398b69014848a"
   integrity sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==
 
-regenerator-runtime@^0.13.4, regenerator-runtime@^0.13.7:
-  version "0.13.7"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz#cac2dacc8a1ea675feaabaeb8ae833898ae46f55"
-  integrity sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==
+regenerator-runtime@^0.13.4, regenerator-runtime@^0.13.7, regenerator-runtime@^0.14.1:
+  version "0.14.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz#356ade10263f685dda125100cd862c1db895327f"
+  integrity sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==
 
 regenerator-transform@^0.14.2:
   version "0.14.5"


### PR DESCRIPTION
`tsdx` hasn't been updated in a few years. While we wait on #193 to be merged (which removes `tsdx`), this fix allows us to use this library in environments that depend on the fix introduced by https://github.com/facebook/regenerator/pull/480.