### PR TITLE
chore: update v3-staker to `v1.0.2`

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@uniswap/sdk-core": "^4.2.0",
     "@uniswap/swap-router-contracts": "^1.2.1",
     "@uniswap/v3-periphery": "^1.1.1",
-    "@uniswap/v3-staker": "1.0.0",
+    "@uniswap/v3-staker": "1.0.2",
     "tiny-invariant": "^1.1.0",
     "tiny-warning": "^1.0.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1592,10 +1592,10 @@
     base64-sol "1.0.1"
     hardhat-watcher "^2.1.1"
 
-"@uniswap/v3-staker@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@uniswap/v3-staker/-/v3-staker-1.0.0.tgz#9a6915ec980852479dfc903f50baf822ff8fa66e"
-  integrity sha512-JV0Qc46Px5alvg6YWd+UIaGH9lDuYG/Js7ngxPit1SPaIP30AlVer1UYB7BRYeUVVxE+byUyIeN5jeQ7LLDjIw==
+"@uniswap/v3-staker@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@uniswap/v3-staker/-/v3-staker-1.0.2.tgz#febad4905903032bb114ab58138c2d5200c87a3c"
+  integrity sha512-+swIh/yhY9GQGyQxT4Gz54aXYLK+uc3qsmIvaAX+FjvhcL9TGOvS9tXbQsCZM4AJW63vj6TLsmHIjGMIePL1BQ==
   dependencies:
     "@openzeppelin/contracts" "3.4.1-solc-0.7-2"
     "@uniswap/v3-core" "1.0.0"


### PR DESCRIPTION
### Issue
Current v3-staker version (1.0.0) depends on a vulnerable version of `@openzeppelin/contracts`.

<img width="944" alt="image" src="https://github.com/Uniswap/v3-sdk/assets/95644202/60073b04-afe6-452c-8cdc-944145bcc143">

### Changelog

1. Update `@uniswap/v3-staker` dependency to `v1.0.2`

